### PR TITLE
Add description related to using docker

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,7 +24,9 @@ git clone
 cd faster-lio/docker
 docker-compose build
 docker-compose up
-```
+```  
+Before entering `docker-compose up` command, you should enter `xhost +local:docker` in the local terminal to enable docker to communicate with Xserver on the host.  
+
 update `bag` file path in `.env`, then run.
 ```bash
 catkin_make


### PR DESCRIPTION
@gaoxiang12   
I add simple comments related to using Docker.  
When I follow the readme and build the environment with Docker, I faced the following error.  
```
fasterlio-ubuntu20_1  | [100%] Built target run_mapping_offline
fasterlio-ubuntu20_1  | ================Docker Env Ready================
fasterlio-ubuntu20_1  | No protocol specified
fasterlio-ubuntu20_1  | Unable to init server: Could not connect: Connection refused
fasterlio-ubuntu20_1  | 
fasterlio-ubuntu20_1  | (lxterminal:1): Gtk-WARNING **: 11:18:47.105: cannot open display: :0
```  

The solution is quite simple, just enter `xhost +local:docker` in the local terminal, before entering `docker-compose up`.   
I thought writing the solution on the readme would be one way for beginners to avoid confusion.  

Thanks,  

