### PR TITLE
Simple fix typo for ouster.launch

### DIFF
--- a/config/ouster64.yaml
+++ b/config/ouster64.yaml
@@ -7,6 +7,7 @@ preprocess:
     lidar_type: 3                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
     scan_line: 64
     blind: 4
+    time_scale: 1e-3
 
 mapping:
     acc_cov: 0.1
@@ -24,8 +25,11 @@ mapping:
 publish:
     path_publish_en:  false
     scan_publish_en:  true       # false: close all the point cloud output
+    scan_effect_pub_en: true    # true: publish the pointscloud of effect point
     dense_publish_en: false       # false: low down the points number in a global-frame point clouds scan.
     scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+
+path_save_en: true
 
 pcd_save:
     pcd_save_en: true

--- a/launch/mapping_ouster64.launch
+++ b/launch/mapping_ouster64.launch
@@ -3,7 +3,7 @@
 
     <arg name="rviz" default="true" />
 
-    <rosparam command="load" file="$(find fast_lio)/config/ouster64.yaml" />
+    <rosparam command="load" file="$(find faster_lio)/config/ouster64.yaml" />
 
     <param name="feature_extract_enable" type="bool" value="0"/>
     <param name="point_filter_num_" type="int" value="4"/>
@@ -12,10 +12,10 @@
     <param name="filter_size_map" type="double" value="0.5" />
     <param name="cube_side_length" type="double" value="1000" />
     <param name="runtime_pos_log_enable" type="bool" value="0" />
-    <node pkg="fast_lio" type="fastlio_mapping" name="laserMapping" output="screen" /> 
+    <node pkg="faster_lio" type="run_mapping_online" name="laserMapping" output="screen" /> 
 
     <group if="$(arg rviz)">
-    <node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_lio)/rviz_cfg/loam_livox.rviz" />
+    <node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find faster_lio)/rviz_cfg/loam_livox.rviz" />
     </group>
 
 </launch>


### PR DESCRIPTION
@gaoxiang12   

Thanks for your great work!  
I'd just fix some typo in `mapping_ouster64.launch`.  
I think that typo was caused by the [FAST-LIO repository](https://github.com/hku-mars/FAST_LIO).  
Thanks,
