### PR TITLE
Pass custom output path via command line

### DIFF
--- a/app/run_mapping_online.cc
+++ b/app/run_mapping_online.cc
@@ -19,6 +19,7 @@ int main(int argc, char **argv) {
     FLAGS_stderrthreshold = google::INFO;
     FLAGS_colorlogtostderr = true;
     google::InitGoogleLogging(argv[0]);
+    google::ParseCommandLineFlags(&argc, &argv, true);
 
     ros::init(argc, argv, "faster_lio");
     ros::NodeHandle nh;


### PR DESCRIPTION
Parse path to save trajectory from command line. It can be passed as an argument in the launch file like 

```
<node pkg="faster_lio" type="run_mapping_online" name="laserMapping" output="screen" args="--traj_log_file /root/Dataset/out_traj.txt"/> 
```