### PR TITLE
Remove duplicate add_definitions statement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -fexceptions -g -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS}")
 
-add_definitions(-DROOT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\")
 add_subdirectory(thirdparty/livox_ros_driver)
 
 include(cmake/packages.cmake)


### PR DESCRIPTION
The code contained a duplicate add_definitions statement for defining the ROOT_DIR macro. This commit removes the redundant statement to improve code clarity and consistency.