### PR TITLE
Fix the non-reproducibility of Faster-LIO: Improve thread safety in by changing vector<bool> to vector<char>

### DIFF
--- a/include/laser_mapping.h
+++ b/include/laser_mapping.h
@@ -107,7 +107,7 @@ class LaserMapping {
     common::VV4F corr_norm_;                          // inlier plane norms
     pcl::VoxelGrid<PointType> voxel_scan_;            // voxel filter for current scan
     std::vector<float> residuals_;                    // point-to-plane residuals
-    std::vector<bool> point_selected_surf_;           // selected points
+    std::vector<char> point_selected_surf_;           // selected points
     common::VV4F plane_coef_;                         // plane coeffs
 
     /// ros pub and sub stuffs

--- a/src/pointcloud_preprocess.cc
+++ b/src/pointcloud_preprocess.cc
@@ -45,7 +45,7 @@ void PointCloudPreprocess::AviaHandler(const livox_ros_driver::CustomMsg::ConstP
     cloud_out_.reserve(plsize);
     cloud_full_.resize(plsize);
 
-    std::vector<bool> is_valid_pt(plsize, false);
+    std::vector<char> is_valid_pt(plsize, false);
     std::vector<uint> index(plsize - 1);
     for (uint i = 0; i < plsize - 1; ++i) {
         index[i] = i + 1;  // 从1开始


### PR DESCRIPTION
1. std::vector<bool> does not guarantee that different elements in the same container can be modified concurrently by different threads. (See https://en.cppreference.com/w/cpp/container/vector_bool).
2. A similar issue has been mentioned in https://github.com/ethz-asl/COIN-LIO/pull/30.
3. This issue in Faster-LIO has been discussed in [GitHub Issue #74](https://github.com/gaoxiang12/faster-lio/issues/74), but unfortunately, no proper solution has been provided, with the only [suggestion](https://github.com/gaoxiang12/faster-lio/issues/74#issuecomment-2081281880) being to switch from multi-threading to single-threading which sacrifices computation speed.
4. Another reason for non-reprodcubility in Faster-LIO has been detailed in https://liobench.github.io/LIOBench/#/Guide/hardware_induced_non_reproducibility/Hardware-induced_non_reproducibility?id=hybrid-architecture-of-1213th-generation-intel%c2%ae-core%e2%84%a2-processors.