### PR TITLE
Support for Livox PointCloud2.

### DIFF
--- a/config/livox.yaml
+++ b/config/livox.yaml
@@ -1,0 +1,42 @@
+common:
+    lid_topic: "/livox/lidar"
+    imu_topic: "/livox/imu"
+    time_sync_en: false # ONLY turn on when external time synchronization is really not possible
+
+preprocess: # set <xfer_format = 0> in livox_ros_driver launch file
+    lidar_type: 6 # 6->LivoxPointXYZRTLT (sensor_msgs::PointCloud2)
+    scan_line: 4
+    blind: 0.5
+
+mapping:
+    acc_cov: 0.1
+    gyr_cov: 0.1
+    b_acc_cov: 0.0001
+    b_gyr_cov: 0.0001
+    fov_degree: 360
+    det_range: 100.0
+    extrinsic_est_en: false # true: enable the online estimation of IMU-LiDAR extrinsic
+    extrinsic_T: [-0.011, -0.02329, 0.04412]
+    extrinsic_R: [1, 0, 0, 0, 1, 0, 0, 0, 1]
+
+publish:
+    path_publish_en: true
+    scan_publish_en: true # false: close all the point cloud output
+    dense_publish_en: false # false: low down the points number in a global-frame point clouds scan.
+    scan_bodyframe_pub_en: true # true: output the point cloud scans in IMU-body-frame
+
+pcd_save:
+    pcd_save_en: true
+    interval:
+        -1 # how many LiDAR frames saved in each pcd file;
+        # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.
+feature_extract_enable: false
+point_filter_num: 1
+max_iteration: 3
+filter_size_surf: 0.1
+filter_size_map: 0.3 # 暂时未用到，代码中为0， 即倾向于将降采样后的scan中的所有点加入map
+cube_side_length: 1000
+
+ivox_grid_resolution: 0.1 # default=0.2
+ivox_nearby_type: 18 # 6, 18, 26
+esti_plane_threshold: 0.1 # default=0.1

--- a/include/pointcloud_preprocess.h
+++ b/include/pointcloud_preprocess.h
@@ -101,9 +101,32 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(robosense_ros::Point,
 )
 // clang-format on
 
+namespace livox_ros {
+struct EIGEN_ALIGN16 Point {
+    PCL_ADD_POINT4D;
+    float intensity;
+    uint8_t tag;
+    uint8_t line;
+    double timestamp;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+}  // namespace livox_ros
+
+// clang-format off
+POINT_CLOUD_REGISTER_POINT_STRUCT(livox_ros::Point,
+                                (float, x, x)
+                                (float, y, y)
+                                (float, z, z)
+                                (float, intensity, intensity)
+                                (std::uint8_t, tag, tag)
+                                (std::uint8_t, line, line)
+                                (double, timestamp, timestamp)
+)
+// clang-format on
+
 namespace faster_lio {
 
-enum class LidarType { AVIA = 1, VELO32, OUST64, HESAIxt32, ROBOSENSE };
+enum class LidarType { AVIA = 1, VELO32, OUST64, HESAIxt32, ROBOSENSE, LIVOX };
 
 /**
  * point cloud preprocess
@@ -135,6 +158,7 @@ class PointCloudPreprocess {
     void Oust64Handler(const sensor_msgs::PointCloud2::ConstPtr &msg);
     void VelodyneHandler(const sensor_msgs::PointCloud2::ConstPtr &msg);
     void HesaiHandler(const sensor_msgs::PointCloud2::ConstPtr &msg);
+    void LivoxHandler(const sensor_msgs::PointCloud2::ConstPtr &msg);
 
     PointCloudType cloud_full_, cloud_out_;
 

--- a/launch/mapping_livox.launch
+++ b/launch/mapping_livox.launch
@@ -1,0 +1,13 @@
+<launch>
+	<!-- Launch file for Livox LiDAR (sensor_msgs::PointCloud2) -->
+	<arg name="rviz" default="false" />
+	<rosparam command="load" file="$(find faster_lio)/config/livox.yaml" />
+	<param name="runtime_pos_log_enable" type="bool" value="true" />
+
+	<node pkg="faster_lio" type="run_mapping_online" name="laserMapping" output="screen" />
+
+	<group if="$(arg rviz)">
+		<node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find faster_lio)/config/rviz/faster_lio.rviz" />
+	</group>
+
+</launch>

--- a/src/laser_mapping.cc
+++ b/src/laser_mapping.cc
@@ -98,7 +98,7 @@ bool LaserMapping::LoadParams(ros::NodeHandle &nh) {
     LOG(INFO) << "lidar_type " << lidar_type;
     if (lidar_type == 1) {
         preprocess_->SetLidarType(LidarType::AVIA);
-        LOG(INFO) << "Using AVIA Lidar";
+        LOG(INFO) << "Using AVIA Lidar (livox_ros_driver::CustomMsg)";
     } else if (lidar_type == 2) {
         preprocess_->SetLidarType(LidarType::VELO32);
         LOG(INFO) << "Using Velodyne 32 Lidar";
@@ -111,6 +111,9 @@ bool LaserMapping::LoadParams(ros::NodeHandle &nh) {
     } else if (lidar_type == 5) {
         preprocess_->SetLidarType(LidarType::ROBOSENSE);
         LOG(INFO) << "Using Robosense Lidar";
+    } else if (lidar_type == 6) {
+        preprocess_->SetLidarType(LidarType::LIVOX);
+        LOG(INFO) << "Using Livox Lidar (sensor_msgs::PointCloud2)";
     } else {
         LOG(WARNING) << "unknown lidar_type";
         return false;
@@ -198,7 +201,7 @@ bool LaserMapping::LoadParamsFromYAML(const std::string &yaml_file) {
     LOG(INFO) << "lidar_type " << lidar_type;
     if (lidar_type == 1) {
         preprocess_->SetLidarType(LidarType::AVIA);
-        LOG(INFO) << "Using AVIA Lidar";
+        LOG(INFO) << "Using AVIA Lidar (livox_ros_driver::CustomMsg)";
     } else if (lidar_type == 2) {
         preprocess_->SetLidarType(LidarType::VELO32);
         LOG(INFO) << "Using Velodyne 32 Lidar";
@@ -211,6 +214,9 @@ bool LaserMapping::LoadParamsFromYAML(const std::string &yaml_file) {
     } else if (lidar_type == 5) {
         preprocess_->SetLidarType(LidarType::ROBOSENSE);
         LOG(INFO) << "Using Robosense Lidar";
+    } else if (lidar_type == 6) {
+        preprocess_->SetLidarType(LidarType::LIVOX);
+        LOG(INFO) << "Using Livox Lidar (sensor_msgs::PointCloud2)";
     } else {
         LOG(WARNING) << "unknown lidar_type";
         return false;


### PR DESCRIPTION
Dear Dr. Gao,

Thank you so much for open-sourcing such an excellent and impressive work!
Wish you a happy Spring Festival in advance!

This Pull Request is based on the problems I encountered in practical applications:

I hope the recorded bags containing point clouds and IMU data can be used by different SLAM algorithms, but the current Livox message format supported by Faster-LIO is only livox_ros_driver::CustomMsg.

livox_ros_driver::CustomMsg cannot be directly visualized in RViz.

In view of the above issues, I hope the livox ros driver can publish messages in the sensor_msg::PointCloud2 format for Faster-LIO to use.

The modified LivoxHandler I made well supports the PointCloud2 published by the livox_ros_driver, and processes the "intensity"/"ring"/"timestamp" accordingly. The details are as follows:

(Assuming you set <xfer_format = 0> in msg_MID360.launch, which means using LivoxPointCloud2)

Livox PointCloud2 (PointXYZRTLT) point cloud format：
float32 x # X axis, unit: m
float32 y # Y axis, unit: m
float32 z # Z axis, unit: m
float32 intensity # Reflectivity value, range: 0.0~255.0
uint8 tag # Livox tag
uint8 line # Laser number in lidar
float64 timestamp # Timestamp of point

Add lidar_type LIVOX, in pointcloud_preprocess.h
Add LivoxHandler to process livox msg.(sensor_msgs::PointCloud2 <PointXYZRTLT>)

Below is the mapping result using two MID360 data synchronized by message_filters::approximateTime:
<img width="2520" height="1680" alt="Screenshot from 2026-02-06 23-21-23" src="https://github.com/user-attachments/assets/af24e607-2ee6-4ac3-a877-1dc385ca288d" />
<img width="2520" height="1680" alt="Screenshot from 2026-02-07 00-37-24" src="https://github.com/user-attachments/assets/3bdda325-1fb8-4d1c-a90c-2cb67d763f85" />
